### PR TITLE
Add duration to alarm macro

### DIFF
--- a/macros/threshold_to_alarm.sql
+++ b/macros/threshold_to_alarm.sql
@@ -22,7 +22,11 @@ with alarms as (
         MAX(begin_thresholds.cumulative_minutes) >= {{ duration_threshold }}
 )
 
-select *
+select
+    begin,
+    stop,
+    cce_id,
+    COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin as duration
 from alarms
 order by begin
 

--- a/models/marts/freeze_kpis.sql
+++ b/models/marts/freeze_kpis.sql
@@ -4,21 +4,14 @@ select
     SUM(
         case
             when
-                COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-                >= interval '48 hours'
+                duration >= interval '48 hours'
                 then 1
             else 0
         end
     ) as long_alarm_count,
-    SUM(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as cumulative_alarm_time,
-    AVG(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as average_alarm_time,
-    MAX(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as longest_alarm_time
+    SUM(duration) as cumulative_alarm_time,
+    AVG(duration) as average_alarm_time,
+    MAX(duration) as longest_alarm_time
 from {{ ref('freeze_fridge_alarms') }}
 where
     COALESCE(stop, '{{ var("now") }}'::timestamptz)

--- a/models/marts/heat_kpis.sql
+++ b/models/marts/heat_kpis.sql
@@ -4,21 +4,14 @@ select
     SUM(
         case
             when
-                COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-                >= interval '48 hours'
+                duration >= interval '48 hours'
                 then 1
             else 0
         end
     ) as long_alarm_count,
-    SUM(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as cumulative_alarm_time,
-    AVG(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as average_alarm_time,
-    MAX(
-        COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-    ) as longest_alarm_time
+    SUM(duration) as cumulative_alarm_time,
+    AVG(duration) as average_alarm_time,
+    MAX(duration) as longest_alarm_time
 from (
     select *
     from {{ ref('heat_freezer_alarms') }}

--- a/models/marts/power_kpis.sql
+++ b/models/marts/power_kpis.sql
@@ -2,12 +2,8 @@ with normal_kpis as (
     select
         cce_id,
         COUNT(*) as alarm_count,
-        SUM(
-            COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-        ) as cumulative_alarm_time,
-        AVG(
-            COALESCE(stop, '{{ var("now") }}'::timestamptz) - begin
-        ) as average_alarm_time
+        SUM(duration) as cumulative_alarm_time,
+        AVG(duration) as average_alarm_time
     from {{ ref('power_alarms') }}
     where
         COALESCE(stop, '{{ var("now") }}'::timestamptz)


### PR DESCRIPTION
Turns out durations are pretty useful! We keep computing it over and over and it'd be nice to index on the column, so let's add it to the database.